### PR TITLE
EMSCRIPTEN -> __EMSCRIPTEN__

### DIFF
--- a/test/checkkeys.c
+++ b/test/checkkeys.c
@@ -19,7 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -195,7 +195,7 @@ main(int argc, char *argv[])
     /* Watch keystrokes */
     done = 0;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, 0, 1);
 #else
     while (!done) {

--- a/test/loopwave.c
+++ b/test/loopwave.c
@@ -24,7 +24,7 @@
 #include <signal.h>
 #endif
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -143,7 +143,7 @@ main(int argc, char *argv[])
     /* Let the audio run */
     SDL_PauseAudio(0);
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, 0, 1);
 #else
     while (!done && (SDL_GetAudioStatus() == SDL_AUDIO_PLAYING))

--- a/test/testdraw2.c
+++ b/test/testdraw2.c
@@ -16,7 +16,7 @@
 #include <stdio.h>
 #include <time.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -276,7 +276,7 @@ main(int argc, char *argv[])
     then = SDL_GetTicks();
     done = 0;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, 0, 1);
 #else
     while (!done) {

--- a/test/testdrawchessboard.c
+++ b/test/testdrawchessboard.c
@@ -17,7 +17,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -116,7 +116,7 @@ main(int argc, char *argv[])
 
 	/* Draw the Image on rendering surface */
 	done = 0;
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, 0, 1);
 #else
     while (!done) {

--- a/test/testgesture.c
+++ b/test/testgesture.c
@@ -22,7 +22,7 @@
 #include "SDL_touch.h"
 #include "SDL_gesture.h"
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -316,7 +316,7 @@ int main(int argc, char* argv[])
       return 1;
     }
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, 0, 1);
 #else
     while(!quitting) {

--- a/test/testgles2.c
+++ b/test/testgles2.c
@@ -14,7 +14,7 @@
 #include <string.h>
 #include <math.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -686,7 +686,7 @@ main(int argc, char *argv[])
     then = SDL_GetTicks();
     done = 0;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, 0, 1);
 #else
     while (!done) {

--- a/test/testintersections.c
+++ b/test/testintersections.c
@@ -16,7 +16,7 @@
 #include <stdio.h>
 #include <time.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -335,7 +335,7 @@ main(int argc, char *argv[])
     then = SDL_GetTicks();
     done = 0;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, 0, 1);
 #else
     while (!done) {

--- a/test/testoverlay2.c
+++ b/test/testoverlay2.c
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -277,7 +277,7 @@ loop()
         }
     }
 
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
     SDL_Delay(fpsdelay);
 #endif
 
@@ -451,7 +451,7 @@ main(int argc, char **argv)
     SDL_EventState(SDL_KEYUP, SDL_IGNORE);
 
     /* Loop, waiting for QUIT or RESIZE */
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, nodelay ? 0 : fps, 1);
 #else
     while (!done) {

--- a/test/testrendercopyex.c
+++ b/test/testrendercopyex.c
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <time.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -204,7 +204,7 @@ main(int argc, char *argv[])
     then = SDL_GetTicks();
     done = 0;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, 0, 1);
 #else
     while (!done) {

--- a/test/testrendertarget.c
+++ b/test/testrendertarget.c
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <time.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -305,7 +305,7 @@ main(int argc, char *argv[])
     then = SDL_GetTicks();
     done = 0;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, 0, 1);
 #else
     while (!done) {

--- a/test/testscale.c
+++ b/test/testscale.c
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <time.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -194,7 +194,7 @@ main(int argc, char *argv[])
     then = SDL_GetTicks();
     done = 0;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, 0, 1);
 #else
     while (!done) {

--- a/test/testsprite2.c
+++ b/test/testsprite2.c
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <time.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -374,7 +374,7 @@ main(int argc, char *argv[])
     then = SDL_GetTicks();
     done = 0;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, 0, 1);
 #else
     while (!done) {

--- a/test/testspriteminimal.c
+++ b/test/testspriteminimal.c
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <time.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -174,7 +174,7 @@ main(int argc, char *argv[])
     /* Main render loop */
     done = 0;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, 0, 1);
 #else
     while (!done) {

--- a/test/teststreaming.c
+++ b/test/teststreaming.c
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -167,7 +167,7 @@ main(int argc, char **argv)
     /* Loop, waiting for QUIT or the escape key */
     frame = 0;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, 0, 1);
 #else
     while (!done) {

--- a/test/testviewport.c
+++ b/test/testviewport.c
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <time.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -28,7 +28,7 @@ static SDLTest_CommonState *state;
 SDL_Rect viewport;
 int done, j;
 SDL_bool use_target = SDL_FALSE;
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 Uint32 wait_start;
 #endif
 
@@ -91,7 +91,7 @@ DrawOnViewport(SDL_Renderer * renderer, SDL_Rect viewport)
 void
 loop()
 {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     /* Avoid using delays */
     if(SDL_GetTicks() - wait_start < 1000)
         return;
@@ -187,7 +187,7 @@ main(int argc, char *argv[])
     done = 0;
     j = 0;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     wait_start = SDL_GetTicks();
     emscripten_set_main_loop(loop, 0, 1);
 #else

--- a/test/testwm2.c
+++ b/test/testwm2.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
 
@@ -137,7 +137,7 @@ main(int argc, char *argv[])
 
     /* Main render loop */
     done = 0;
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, 0, 1);
 #else
     while (!done) {


### PR DESCRIPTION
We'd like to remove `EMSCRIPTEN` one day as a pre-processor definition as things should use `__EMSCRIPTEN__` instead.
