### PR TITLE
Fix mouse wheel event Y-coordinate to match desktop version

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -328,7 +328,7 @@ int
 Emscripten_HandleWheel(int eventType, const EmscriptenWheelEvent *wheelEvent, void *userData)
 {
     SDL_WindowData *window_data = userData;
-    SDL_SendMouseWheel(window_data->window, 0, wheelEvent->deltaX, wheelEvent->deltaY);
+    SDL_SendMouseWheel(window_data->window, 0, wheelEvent->deltaX, -wheelEvent->deltaY);
     return 1;
 }
 


### PR DESCRIPTION
This fixes mouse wheel direction y-values (positive up, negative down, same as desktop SDL2).
Important note: if OS X has "natural scrolling" enabled the wheel direction appears to be reversed. Edward Rudd is working on a portable fix for this which should eventually be added to SDL2 main repository.
