### PR TITLE
Change SDL pixel format to match HTML Canvas.

### DIFF
--- a/src/video/emscripten/SDL_emscriptenframebuffer.c
+++ b/src/video/emscripten/SDL_emscriptenframebuffer.c
@@ -29,7 +29,7 @@
 int Emscripten_CreateWindowFramebuffer(_THIS, SDL_Window * window, Uint32 * format, void ** pixels, int *pitch)
 {
     SDL_Surface *surface;
-    const Uint32 surface_format = SDL_PIXELFORMAT_RGB888;
+    const Uint32 surface_format = SDL_PIXELFORMAT_BGR888;
     int w, h;
     int bpp;
     Uint32 Rmask, Gmask, Bmask, Amask;
@@ -88,9 +88,9 @@ int Emscripten_UpdateWindowFramebuffer(_THIS, SDL_Window * window, const SDL_Rec
             num = data.length;
             while (dst < num) {
                 var val = HEAP32[src]; // This is optimized. Instead, we could do {{{ makeGetValue('buffer', 'dst', 'i32') }}};
-                data[dst  ] = (val >> 16) & 0xff;
+                data[dst  ] = val & 0xff;
                 data[dst+1] = (val >> 8) & 0xff;
-                data[dst+2] = val & 0xff;
+                data[dst+2] = (val >> 16) & 0xff;
                 data[dst+3] = isScreen ? 0xff : ((val >> 24) & 0xff);
                 src++;
                 dst += 4;

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -132,7 +132,7 @@ Emscripten_VideoInit(_THIS)
     int is_fullscreen;
 
     /* Use a fake 32-bpp desktop mode */
-    mode.format = SDL_PIXELFORMAT_RGB888;
+    mode.format = SDL_PIXELFORMAT_BGR888;
 
     emscripten_get_canvas_size(&mode.w, &mode.h, &is_fullscreen);
 


### PR DESCRIPTION
Both standard createImageData() and CanvasPixelArray order bytes
as red, green, blue, alpha. Emscripten is little endian, and the
the order of characters in SDL_PIXELFORMAT_ defines refers to
most to least significant order in a word, so this corresponds
to BGR order. The pixel format must match because
Emscripten_UpdateWindowFramebuffer() copies 32 bits without
rearranging when not using CanvasPixelArray.
Otherwise, red and blue are swapped.
